### PR TITLE
fix(docs): microsecond amount typo in `from_hms_micro` docs

### DIFF
--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -338,7 +338,7 @@ impl NaiveTime {
 
     /// Makes a new `NaiveTime` from hour, minute, second and microsecond.
     ///
-    /// The microsecond part is allowed to exceed 1,000,000,000 in order to represent a
+    /// The microsecond part is allowed to exceed 1,000,000 in order to represent a
     /// [leap second](#leap-second-handling), but only when `sec == 59`.
     ///
     /// # Panics


### PR DESCRIPTION
Thanks for the awesome library! 

I was really confused for a bit (and maybe I still am), but I think there is a typo in the docs around `from_hms_micro_opt` -- I'm assuming here that the microseconds should be above `1_000_000` to represent (the fractions? of) a leap second, when seconds is 59.